### PR TITLE
fix(gateway): score submission idempotency + /v1/studio/:addr/scores endpoint

### DIFF
--- a/packages/gateway/src/persistence/postgres/migrations/005_score_dedup.sql
+++ b/packages/gateway/src/persistence/postgres/migrations/005_score_dedup.sql
@@ -1,0 +1,37 @@
+-- Migration 005: Cross-workflow ScoreSubmission idempotency
+-- Run with: psql -d gateway -f 005_score_dedup.sql
+--
+-- Background: prior to this migration, SubmitScoreDirectStep had no
+-- cross-workflow idempotency guard. Multiple verifier instances polling
+-- the same gateway pending queue could both discover the same work
+-- item, both run their local scoring pipeline, and both create separate
+-- ScoreSubmission workflows that each reached COMPLETED for the same
+-- data_hash. The compare-page leaderboard SQL AVGs across all COMPLETED
+-- ScoreSubmission rows per agent, so duplicate rows directly polluted
+-- canonical per-agent scores.
+--
+-- Fix layers (defence in depth):
+--   1. Application-level check in SubmitScoreDirectStep.execute before
+--      marking score_confirmed — catches the common case.
+--   2. This partial unique index — catches the TOCTOU race when two
+--      workflows pass the check above in the same millisecond and
+--      both try to transition to COMPLETED. Whichever UPDATE fires
+--      second receives pg error 23505, which the workflow step handler
+--      catches and converts into a no-op success ("first winner is
+--      canonical, this workflow is a duplicate").
+--
+-- The filter `state = 'COMPLETED'` means rows in CREATED/RUNNING/
+-- STALLED/FAILED states can coexist freely for the same data_hash —
+-- only the transition _into_ COMPLETED is serialised, which is exactly
+-- where duplication matters.
+
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_score_submission_data_hash_completed
+    ON workflows ((input->>'data_hash'))
+    WHERE type = 'ScoreSubmission' AND state = 'COMPLETED';
+
+INSERT INTO schema_migrations (version) VALUES (5)
+    ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/packages/gateway/src/persistence/postgres/persistence.ts
+++ b/packages/gateway/src/persistence/postgres/persistence.ts
@@ -129,6 +129,38 @@ DO $$ BEGIN
 END $$;
 `;
 
+// Migration V5: cross-workflow ScoreSubmission idempotency.
+//
+// Background: without this constraint, multiple verifier instances polling
+// the gateway's pending queue can both discover the same work item and both
+// persist separate ScoreSubmission workflows that each reach COMPLETED for
+// the same data_hash. The compare-page leaderboard AVGs across all COMPLETED
+// ScoreSubmission rows per agent, so duplicate rows directly pollute the
+// canonical per-agent scores that drive the product's core comparison
+// signal. The zombie-Railway-replica incident on 2026-04-11 demonstrated
+// this in production (17 score submissions for 12 unique data_hashes, all
+// with identical deterministic score dims 0-2 but diverging LLM-dependent
+// dims 3-4 — unambiguous evidence of two independent verifier runs).
+//
+// The partial unique index filters on ``state = 'COMPLETED'`` so that
+// CREATED/RUNNING/STALLED/FAILED rows can coexist freely for the same
+// data_hash — only the transition _into_ COMPLETED is serialised, which is
+// exactly where duplication matters. This layer catches the TOCTOU race
+// between SubmitScoreDirectStep's application-level check and its progress
+// append; on violation the workflow step handler converts pg error 23505
+// into a no-op success ("first winner is canonical").
+const MIGRATION_V5_SQL = `
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM schema_migrations WHERE version = 5) THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_score_submission_data_hash_completed
+      ON workflows ((input->>'data_hash'))
+      WHERE type = 'ScoreSubmission' AND state = 'COMPLETED';
+
+    INSERT INTO schema_migrations (version) VALUES (5);
+  END IF;
+END $$;
+`;
+
 /**
  * Ensure the database schema exists. Idempotent — safe to call on every startup.
  * Uses CREATE TABLE IF NOT EXISTS so it's a no-op on an already-initialized DB.
@@ -138,6 +170,7 @@ export async function runMigrations(pool: Pool): Promise<void> {
   await pool.query(MIGRATION_V2_SQL);
   await pool.query(MIGRATION_V3_SQL);
   await pool.query(MIGRATION_V4_SQL);
+  await pool.query(MIGRATION_V5_SQL);
 }
 
 // =============================================================================
@@ -608,6 +641,53 @@ export class PostgresWorkflowPersistence implements WorkflowPersistence {
     `;
     const result = await this.pool.query(query, [dataHash]);
     return result.rows.map((row) => this.rowToRecord(row));
+  }
+
+  async findScoresForStudio(
+    studioAddress: string,
+    filter: { workerAddress?: string; validatorAddress?: string },
+    limit: number,
+    offset: number,
+  ): Promise<{ records: WorkflowRecord[]; total: number }> {
+    const conditions: string[] = [
+      `type = 'ScoreSubmission'`,
+      `state = 'COMPLETED'`,
+      `LOWER(input->>'studio_address') = LOWER($1)`,
+    ];
+    const values: unknown[] = [studioAddress];
+
+    if (filter.workerAddress) {
+      values.push(filter.workerAddress);
+      conditions.push(`LOWER(input->>'worker_address') = LOWER($${values.length})`);
+    }
+    if (filter.validatorAddress) {
+      values.push(filter.validatorAddress);
+      conditions.push(`LOWER(input->>'validator_address') = LOWER($${values.length})`);
+    }
+
+    const where = conditions.join(' AND ');
+
+    const countResult = await this.pool.query(
+      `SELECT COUNT(*) AS count FROM workflows WHERE ${where}`,
+      values,
+    );
+    const total = Number(countResult.rows[0]?.count ?? 0);
+
+    values.push(limit, offset);
+    const limitIdx = values.length - 1;
+    const offsetIdx = values.length;
+
+    const query = `
+      SELECT id, type, created_at, updated_at,
+             state, step, step_attempts,
+             input, progress, error, signer
+      FROM workflows
+      WHERE ${where}
+      ORDER BY created_at DESC
+      LIMIT $${limitIdx} OFFSET $${offsetIdx}
+    `;
+    const result = await this.pool.query(query, values);
+    return { records: result.rows.map((row) => this.rowToRecord(row)), total };
   }
 
   // ===========================================================================

--- a/packages/gateway/src/routes/public-api.ts
+++ b/packages/gateway/src/routes/public-api.ts
@@ -542,6 +542,101 @@ export function createPublicApiRoutes(config: PublicApiConfig): Router {
   );
 
   // =========================================================================
+  // GET /v1/studio/:address/scores (gated — requires API key)
+  //
+  // Canonical per-work score vectors for every completed ScoreSubmission
+  // in this studio, optionally filtered by worker_address or
+  // validator_address. This is the cross-verifier view: scores from
+  // every verifier that has submitted for the studio, not only those
+  // known to any single agent-server instance.
+  //
+  // Primary consumer: agent-server /v1/verify/results, which reads this
+  // endpoint and merges its local ReAct rationale onto the canonical
+  // rows for the compare dashboard.
+  // =========================================================================
+
+  router.get(
+    '/v1/studio/:address/scores',
+    requireEvidenceKey,
+    async (req: Request, res: Response) => {
+      const address = req.params.address;
+
+      if (!address || !address.startsWith('0x') || address.length !== 42) {
+        res.status(400).json({
+          version: API_VERSION,
+          error: {
+            code: 'INVALID_STUDIO_ADDRESS',
+            message: 'Studio address must be a 0x-prefixed 20-byte hex string (42 chars)',
+          },
+        });
+        return;
+      }
+
+      if (!workDataReader) {
+        res.status(503).json({
+          version: API_VERSION,
+          error: {
+            code: 'SERVICE_UNAVAILABLE',
+            message: 'Work data service not configured',
+          },
+        });
+        return;
+      }
+
+      const isHexAddr = (v: unknown): v is string =>
+        typeof v === 'string' && /^0x[0-9a-fA-F]{40}$/.test(v);
+
+      const rawWorker = req.query.worker_address;
+      if (rawWorker !== undefined && !isHexAddr(rawWorker)) {
+        res.status(400).json({
+          version: API_VERSION,
+          error: {
+            code: 'INVALID_WORKER_ADDRESS',
+            message: 'worker_address must be a 0x-prefixed 20-byte hex string (42 chars)',
+          },
+        });
+        return;
+      }
+      const rawValidator = req.query.validator_address;
+      if (rawValidator !== undefined && !isHexAddr(rawValidator)) {
+        res.status(400).json({
+          version: API_VERSION,
+          error: {
+            code: 'INVALID_VALIDATOR_ADDRESS',
+            message: 'validator_address must be a 0x-prefixed 20-byte hex string (42 chars)',
+          },
+        });
+        return;
+      }
+
+      const limit = Math.min(Math.max(1, Number(req.query.limit) || 100), 500);
+      const offset = Math.max(0, Number(req.query.offset) || 0);
+
+      try {
+        const data = await workDataReader.getStudioScores(
+          address,
+          {
+            workerAddress: rawWorker as string | undefined,
+            validatorAddress: rawValidator as string | undefined,
+          },
+          limit,
+          offset,
+        );
+        res.json({ version: API_VERSION, data });
+      } catch (err) {
+        console.error(`[studio-scores] studio=${address} error:`, err);
+        res.status(500).json({
+          version: API_VERSION,
+          error: {
+            code: 'INTERNAL_ERROR',
+            message: 'An unexpected error occurred',
+          },
+        });
+      }
+    },
+  );
+
+  // =========================================================================
   // GET /v1/skills — skill discovery (public, no auth)
   // =========================================================================
 

--- a/packages/gateway/src/services/work-data-reader.ts
+++ b/packages/gateway/src/services/work-data-reader.ts
@@ -139,6 +139,30 @@ export interface WorkflowQuerySource {
   findFinalizedWorkForStudio(studioAddress: string, limit: number, offset: number): Promise<{ records: WorkflowRecord[]; total: number }>;
   findAllWorkForStudio(studioAddress: string, limit: number, offset: number): Promise<{ records: WorkflowRecord[]; total: number }>;
   findScoresForDataHash(dataHash: string): Promise<WorkflowRecord[]>;
+  findScoresForStudio(
+    studioAddress: string,
+    filter: { workerAddress?: string; validatorAddress?: string },
+    limit: number,
+    offset: number,
+  ): Promise<{ records: WorkflowRecord[]; total: number }>;
+}
+
+export interface StudioScoreRecord {
+  data_hash: string;
+  studio_address: string;
+  worker_address: string;
+  validator_address: string;
+  scores_bp: number[];
+  submitted_at: string;
+  workflow_id: string;
+}
+
+export interface StudioScoresResult {
+  studio: string;
+  scores: StudioScoreRecord[];
+  total: number;
+  limit: number;
+  offset: number;
 }
 
 // =============================================================================
@@ -419,6 +443,60 @@ export class WorkDataReader {
     entries.sort((a, b) => b.submissions - a.submissions);
 
     return { studio: studioAddress, entries, total: entries.length };
+  }
+
+  /**
+   * Return canonical per-work scores for a studio — every completed
+   * ScoreSubmission for this studio, optionally filtered by worker or
+   * validator address, in submitted-at-descending order.
+   *
+   * This is the cross-verifier canonical view: it surfaces scores from
+   * every verifier that has ever submitted for the studio, not just the
+   * one verifier instance a given agent-server is aware of locally. The
+   * agent-server's /v1/verify/results endpoint reads this view and merges
+   * its local rationale onto the canonical rows for the compare-page
+   * dashboard.
+   */
+  async getStudioScores(
+    studioAddress: string,
+    filter: { workerAddress?: string; validatorAddress?: string },
+    limit: number,
+    offset: number,
+  ): Promise<StudioScoresResult> {
+    const addr = studioAddress.toLowerCase();
+    const { records, total } = await this.querySource.findScoresForStudio(
+      addr, filter, limit, offset,
+    );
+
+    const scores: StudioScoreRecord[] = [];
+    for (const record of records) {
+      const input = record.input as ScoreSubmissionInput;
+      if (!Array.isArray(input.scores) || input.scores.length === 0) continue;
+
+      // worker_address is optional on ScoreSubmissionInput (direct-mode
+      // resolves it at runtime from the matching WorkSubmission). Prefer
+      // the resolved value from progress; fall back to the input value;
+      // default to empty string if neither is available (downstream
+      // clients treat empty worker_address as "unknown").
+      const progress = record.progress as Record<string, unknown>;
+      const resolvedWorker = progress.resolved_worker_address;
+      const workerAddress =
+        (typeof resolvedWorker === 'string' && resolvedWorker) ||
+        input.worker_address ||
+        '';
+
+      scores.push({
+        data_hash: input.data_hash,
+        studio_address: input.studio_address,
+        worker_address: workerAddress,
+        validator_address: input.validator_address,
+        scores_bp: input.scores as number[],
+        submitted_at: new Date(record.updated_at).toISOString(),
+        workflow_id: record.id,
+      });
+    }
+
+    return { studio: studioAddress, scores, total, limit, offset };
   }
 
   async getEvidenceViewer(dataHash: string): Promise<EvidenceViewerData | null> {

--- a/packages/gateway/src/workflows/persistence.ts
+++ b/packages/gateway/src/workflows/persistence.ts
@@ -70,6 +70,34 @@ export interface WorkflowPersistence {
    * Used by ScoreSubmission to resolve the on-chain worker address.
    */
   findWorkByDataHash(dataHash: string): Promise<WorkflowRecord | null>;
+
+  /**
+   * Check whether any ScoreSubmission workflow has already reached
+   * COMPLETED for the given data_hash.
+   *
+   * Used by SubmitScoreDirectStep as a cross-workflow idempotency
+   * guard: multiple verifier instances can race on the same pending
+   * work item during the window between discovery and submission, and
+   * without this check both would persist duplicate score rows — which
+   * then pollute the compare-page leaderboard averages.
+   */
+  hasCompletedScoreForDataHash(dataHash: string): Promise<boolean>;
+
+  /**
+   * List completed ScoreSubmission workflows for a studio, optionally
+   * filtered by validator_address OR worker_address.
+   *
+   * Used by the public /v1/studio/:addr/scores endpoint so that
+   * downstream consumers (the compare dashboard, agent-server's
+   * /v1/verify/results merge) can see every canonical score for a
+   * studio regardless of which verifier instance produced it.
+   */
+  findScoresForStudio(
+    studioAddress: string,
+    filter: { workerAddress?: string; validatorAddress?: string },
+    limit: number,
+    offset: number,
+  ): Promise<{ records: WorkflowRecord[]; total: number }>;
 }
 
 // =============================================================================
@@ -295,6 +323,32 @@ export class InMemoryWorkflowPersistence implements WorkflowPersistence {
       if (input.data_hash === dataHash) results.push(structuredClone(record));
     }
     return results;
+  }
+
+  async findScoresForStudio(
+    studioAddress: string,
+    filter: { workerAddress?: string; validatorAddress?: string },
+    limit: number,
+    offset: number,
+  ): Promise<{ records: WorkflowRecord[]; total: number }> {
+    const studio = studioAddress.toLowerCase();
+    const worker = filter.workerAddress?.toLowerCase();
+    const validator = filter.validatorAddress?.toLowerCase();
+
+    const matching: WorkflowRecord[] = [];
+    for (const record of this.workflows.values()) {
+      if (record.type !== 'ScoreSubmission' || record.state !== 'COMPLETED') continue;
+      const input = record.input as Record<string, unknown>;
+      if ((input.studio_address as string)?.toLowerCase() !== studio) continue;
+      if (worker && (input.worker_address as string)?.toLowerCase() !== worker) continue;
+      if (validator && (input.validator_address as string)?.toLowerCase() !== validator) continue;
+      matching.push(record);
+    }
+
+    matching.sort((a, b) => b.created_at - a.created_at);
+    const total = matching.length;
+    const sliced = matching.slice(offset, offset + limit).map(r => structuredClone(r));
+    return { records: sliced, total };
   }
 
   // For testing: clear all data

--- a/packages/gateway/src/workflows/score-submission.ts
+++ b/packages/gateway/src/workflows/score-submission.ts
@@ -185,7 +185,31 @@ export class SubmitScoreDirectStep implements StepExecutor<ScoreSubmissionRecord
   async execute(workflow: ScoreSubmissionRecord): Promise<StepResult> {
     const { input, progress } = workflow;
 
+    // Per-workflow re-entrancy guard (e.g. after crash/restart).
     if (progress.score_confirmed) {
+      return { type: 'SUCCESS', nextStep: null };
+    }
+
+    // Cross-workflow idempotency guard. Multiple verifier instances can
+    // race on the same pending work item during the window between
+    // discovery and submission — without this check both would persist
+    // separate ScoreSubmission workflows for the same data_hash, which
+    // then inflates leaderboard averages (queryLeaderboardRows AVGs
+    // across all COMPLETED rows) and breaks compare-page canonical
+    // scoring. The first winner is canonical; later workflows for the
+    // same data_hash no-op into a success so the caller doesn't see a
+    // retry loop or error.
+    if (await this.persistence.hasCompletedScoreForDataHash(input.data_hash)) {
+      console.log(
+        `[SUBMIT_SCORE_DIRECT] duplicate skipped: data_hash=${input.data_hash} ` +
+        `already has a completed score (workflow=${workflow.id}, validator=${input.validator_address})`,
+      );
+      await this.persistence.appendProgress(workflow.id, {
+        score_confirmed: true,
+        score_confirmed_at: Date.now(),
+        settlement: 'off-chain',
+        duplicate_skipped: true,
+      });
       return { type: 'SUCCESS', nextStep: null };
     }
 
@@ -221,17 +245,63 @@ export class SubmitScoreDirectStep implements StepExecutor<ScoreSubmissionRecord
       `[SUBMIT_SCORE_DIRECT] off-chain score persisted: data_hash=${input.data_hash} worker=${resolvedWorkerAddress} scores=[${input.scores.join(',')}] validator=${input.validator_address}`,
     );
 
-    await this.persistence.appendProgress(workflow.id, {
-      score_confirmed: true,
-      score_confirmed_at: Date.now(),
-      resolved_worker_address: resolvedWorkerAddress,
-      settlement: 'off-chain',
-    });
+    try {
+      await this.persistence.appendProgress(workflow.id, {
+        score_confirmed: true,
+        score_confirmed_at: Date.now(),
+        resolved_worker_address: resolvedWorkerAddress,
+        settlement: 'off-chain',
+      });
+    } catch (err) {
+      // DB-level defence-in-depth: the partial unique index on
+      // (input->>'data_hash') WHERE type='ScoreSubmission' AND
+      // state='COMPLETED' (see migrations/002_score_dedup.sql) closes
+      // the TOCTOU window that the check above leaves open. If two
+      // workflows both pass the cross-workflow idempotency check in
+      // the same millisecond, whichever transitions to COMPLETED
+      // second will trip pg error 23505. Treat it the same as the
+      // above: first winner is canonical, this workflow no-ops.
+      if (isDuplicateScoreViolation(err)) {
+        console.log(
+          `[SUBMIT_SCORE_DIRECT] TOCTOU duplicate detected via unique index: ` +
+          `data_hash=${input.data_hash} workflow=${workflow.id}`,
+        );
+        return { type: 'SUCCESS', nextStep: null };
+      }
+      throw err;
+    }
 
     console.log(`[SUBMIT_SCORE_DIRECT] workflow ${workflow.id} marked COMPLETED (off-chain)`);
 
     return { type: 'SUCCESS', nextStep: null };
   }
+}
+
+/**
+ * Detect the Postgres unique-violation (23505) thrown by the
+ * ``idx_score_submission_data_hash_completed`` partial unique index.
+ * The exact constraint name lives in migrations/002_score_dedup.sql.
+ *
+ * Accepts any throwable (including wrapped errors from the pg driver)
+ * and returns true only for this specific constraint — other unique
+ * violations (e.g. on ``workflows.id``) should propagate.
+ */
+function isDuplicateScoreViolation(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const candidate = err as {
+    code?: string;
+    constraint?: string;
+    cause?: unknown;
+  };
+  if (candidate.code === '23505') {
+    if (!candidate.constraint) return true;
+    return candidate.constraint === 'idx_score_submission_data_hash_completed';
+  }
+  // Some drivers wrap the pg error — peek one level deeper.
+  if (candidate.cause && typeof candidate.cause === 'object') {
+    return isDuplicateScoreViolation(candidate.cause);
+  }
+  return false;
 }
 
 /**

--- a/packages/gateway/test/integration/context-verifier-flow.test.ts
+++ b/packages/gateway/test/integration/context-verifier-flow.test.ts
@@ -111,6 +111,7 @@ class MockQuerySource implements WorkflowQuerySource {
   async findPendingWorkForStudio() { return { records: [], total: 0 }; }
   async findAllWorkForStudio() { return { records: [], total: 0 }; }
   async findScoresForDataHash() { return []; }
+  async findScoresForStudio() { return { records: [], total: 0 }; }
 }
 
 function makeWorkRecord(overrides?: {

--- a/packages/gateway/test/unit/public-api.test.ts
+++ b/packages/gateway/test/unit/public-api.test.ts
@@ -64,6 +64,19 @@ class MockWorkflowQuerySource implements WorkflowQuerySource {
     this.scores.add(dataHash);
   }
 
+  /**
+   * Insert a full ScoreSubmission WorkflowRecord into the store so
+   * that findScoresForStudio / findScoresForDataHash can surface it.
+   * Used for /v1/studio/:addr/scores coverage.
+   */
+  addScoreWorkflow(record: WorkflowRecord): void {
+    this.allRecords.push(record);
+    const dataHash = (record.input as Record<string, unknown>).data_hash as string;
+    if (dataHash && record.state === 'COMPLETED') {
+      this.scores.add(dataHash);
+    }
+  }
+
   addClosedEpoch(studio: string, epoch: number): void {
     this.closedEpochs.add(`${studio}:${epoch}`);
   }
@@ -158,6 +171,29 @@ class MockWorkflowQuerySource implements WorkflowQuerySource {
       if (input.data_hash === dataHash) results.push(record);
     }
     return results;
+  }
+
+  async findScoresForStudio(
+    studioAddress: string,
+    filter: { workerAddress?: string; validatorAddress?: string },
+    limit: number,
+    offset: number,
+  ): Promise<{ records: WorkflowRecord[]; total: number }> {
+    const studio = studioAddress.toLowerCase();
+    const worker = filter.workerAddress?.toLowerCase();
+    const validator = filter.validatorAddress?.toLowerCase();
+
+    const matching: WorkflowRecord[] = [];
+    for (const record of this.allRecords) {
+      if (record.type !== 'ScoreSubmission' || record.state !== 'COMPLETED') continue;
+      const input = record.input as Record<string, unknown>;
+      if ((input.studio_address as string)?.toLowerCase() !== studio) continue;
+      if (worker && (input.worker_address as string)?.toLowerCase() !== worker) continue;
+      if (validator && (input.validator_address as string)?.toLowerCase() !== validator) continue;
+      matching.push(record);
+    }
+    matching.sort((a, b) => b.created_at - a.created_at);
+    return { records: matching.slice(offset, offset + limit), total: matching.length };
   }
 }
 
@@ -1297,6 +1333,193 @@ describe('Public API — GET /v1/studio/:address/work', () => {
     const work = data.work as unknown[];
     expect(work.length).toBe(0);
     expect(data.total).toBe(0);
+  });
+});
+
+// =============================================================================
+// Tests — GET /v1/studio/:address/scores (cross-verifier canonical view)
+// =============================================================================
+
+describe('Public API — GET /v1/studio/:address/scores', () => {
+  const STUDIO = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC';
+  const WORKER_A = '0x' + 'aa'.repeat(20);
+  const WORKER_B = '0x' + 'bb'.repeat(20);
+  const VALIDATOR = '0xf81043d7866F5a90836a65E6ea37d38a38716F69';
+
+  function makeStudioScoreRecord(
+    id: string,
+    dataHash: string,
+    workerAddress: string,
+    scoresBp: number[],
+    updatedAt: number,
+  ): WorkflowRecord {
+    return {
+      id,
+      type: 'ScoreSubmission',
+      state: 'COMPLETED',
+      step: 'DONE',
+      step_attempts: 0,
+      created_at: updatedAt,
+      updated_at: updatedAt,
+      input: {
+        studio_address: STUDIO,
+        epoch: 1,
+        validator_address: VALIDATOR,
+        data_hash: dataHash,
+        scores: scoresBp,
+        salt: '0x' + '00'.repeat(32),
+        signer_address: VALIDATOR,
+        worker_address: workerAddress,
+        mode: 'direct',
+      },
+      progress: {
+        score_confirmed: true,
+        resolved_worker_address: workerAddress,
+        settlement: 'off-chain',
+      },
+      signer: VALIDATOR,
+    };
+  }
+
+  it('returns canonical scores for a studio with API key', async () => {
+    const reader = new MockReputationReader();
+    const qs = new MockWorkflowQuerySource();
+    qs.addScoreWorkflow(makeStudioScoreRecord(
+      'wf-score-1', '0x' + '1'.repeat(64), WORKER_A,
+      [7000, 0, 699, 3000, 2500], 1700000000000,
+    ));
+    qs.addScoreWorkflow(makeStudioScoreRecord(
+      'wf-score-2', '0x' + '2'.repeat(64), WORKER_B,
+      [5249, 2500, 875, 3000, 2500], 1700001000000,
+    ));
+    const workDataReader = new WorkDataReader(qs);
+    const apiKeys = new Set(['test-key']);
+    const app = buildApp(reader, workDataReader, apiKeys);
+
+    const { status, body } = await get(
+      app,
+      `/v1/studio/${STUDIO}/scores`,
+      { 'x-api-key': 'test-key' },
+    );
+
+    expect(status).toBe(200);
+    const data = body.data as Record<string, unknown>;
+    expect(data.studio).toBe(STUDIO);
+    expect(data.total).toBe(2);
+    const scores = data.scores as Array<Record<string, unknown>>;
+    expect(scores).toHaveLength(2);
+
+    // Newer row first (DESC by updated_at).
+    expect(scores[0].workflow_id).toBe('wf-score-2');
+    expect(scores[0].worker_address).toBe(WORKER_B);
+    expect(scores[0].validator_address).toBe(VALIDATOR);
+    expect(scores[0].scores_bp).toEqual([5249, 2500, 875, 3000, 2500]);
+
+    expect(scores[1].workflow_id).toBe('wf-score-1');
+    expect(scores[1].worker_address).toBe(WORKER_A);
+  });
+
+  it('filters by worker_address', async () => {
+    const reader = new MockReputationReader();
+    const qs = new MockWorkflowQuerySource();
+    qs.addScoreWorkflow(makeStudioScoreRecord(
+      'wf-score-a', '0x' + '1'.repeat(64), WORKER_A,
+      [7000, 0, 699, 3000, 2500], 1700000000000,
+    ));
+    qs.addScoreWorkflow(makeStudioScoreRecord(
+      'wf-score-b', '0x' + '2'.repeat(64), WORKER_B,
+      [5249, 2500, 875, 3000, 2500], 1700001000000,
+    ));
+    const workDataReader = new WorkDataReader(qs);
+    const apiKeys = new Set(['test-key']);
+    const app = buildApp(reader, workDataReader, apiKeys);
+
+    const { status, body } = await get(
+      app,
+      `/v1/studio/${STUDIO}/scores?worker_address=${WORKER_A}`,
+      { 'x-api-key': 'test-key' },
+    );
+
+    expect(status).toBe(200);
+    const data = body.data as Record<string, unknown>;
+    expect(data.total).toBe(1);
+    const scores = data.scores as Array<Record<string, unknown>>;
+    expect(scores).toHaveLength(1);
+    expect(scores[0].worker_address).toBe(WORKER_A);
+  });
+
+  it('returns 400 for invalid studio address', async () => {
+    const reader = new MockReputationReader();
+    const qs = new MockWorkflowQuerySource();
+    const workDataReader = new WorkDataReader(qs);
+    const apiKeys = new Set(['test-key']);
+    const app = buildApp(reader, workDataReader, apiKeys);
+
+    const { status, body } = await get(
+      app,
+      '/v1/studio/not-an-address/scores',
+      { 'x-api-key': 'test-key' },
+    );
+
+    expect(status).toBe(400);
+    const error = body.error as Record<string, unknown>;
+    expect(error.code).toBe('INVALID_STUDIO_ADDRESS');
+  });
+
+  it('returns 400 for malformed worker_address filter', async () => {
+    const reader = new MockReputationReader();
+    const qs = new MockWorkflowQuerySource();
+    const workDataReader = new WorkDataReader(qs);
+    const apiKeys = new Set(['test-key']);
+    const app = buildApp(reader, workDataReader, apiKeys);
+
+    const { status, body } = await get(
+      app,
+      `/v1/studio/${STUDIO}/scores?worker_address=not-hex`,
+      { 'x-api-key': 'test-key' },
+    );
+
+    expect(status).toBe(400);
+    const error = body.error as Record<string, unknown>;
+    expect(error.code).toBe('INVALID_WORKER_ADDRESS');
+  });
+
+  it('returns 401 without API key', async () => {
+    const reader = new MockReputationReader();
+    const qs = new MockWorkflowQuerySource();
+    const workDataReader = new WorkDataReader(qs);
+    const apiKeys = new Set(['test-key']);
+    const app = buildApp(reader, workDataReader, apiKeys);
+
+    const { status } = await get(app, `/v1/studio/${STUDIO}/scores`);
+    expect(status).toBe(401);
+  });
+
+  it('respects pagination limit', async () => {
+    const reader = new MockReputationReader();
+    const qs = new MockWorkflowQuerySource();
+    for (let i = 0; i < 5; i++) {
+      qs.addScoreWorkflow(makeStudioScoreRecord(
+        `wf-score-${i}`, '0x' + i.toString(16).padStart(64, '0'),
+        WORKER_A, [1000, 2000, 3000, 4000, 5000], 1700000000000 + i * 1000,
+      ));
+    }
+    const workDataReader = new WorkDataReader(qs);
+    const apiKeys = new Set(['test-key']);
+    const app = buildApp(reader, workDataReader, apiKeys);
+
+    const { status, body } = await get(
+      app,
+      `/v1/studio/${STUDIO}/scores?limit=2`,
+      { 'x-api-key': 'test-key' },
+    );
+
+    expect(status).toBe(200);
+    const data = body.data as Record<string, unknown>;
+    const scores = data.scores as unknown[];
+    expect(scores.length).toBe(2);
+    expect(data.total).toBe(5);
+    expect(data.limit).toBe(2);
   });
 });
 

--- a/packages/gateway/test/unit/score-submission.test.ts
+++ b/packages/gateway/test/unit/score-submission.test.ts
@@ -836,6 +836,75 @@ describe('E. ScoreSubmission Direct Mode (MVP)', () => {
     expect(finalWorkflow?.state).toBe('COMPLETED');
     expect(finalWorkflow?.progress.score_confirmed).toBe(true);
   });
+
+  // ---------------------------------------------------------------------
+  // Cross-workflow idempotency (fixes the 2026-04-11 duplicate-scoring
+  // incident). Two verifier instances racing on the same pending work
+  // item must not both persist a COMPLETED ScoreSubmission for the same
+  // data_hash — the first winner is canonical, the second no-ops with
+  // duplicate_skipped=true on its progress.
+  // ---------------------------------------------------------------------
+
+  it('second SUBMIT_SCORE_DIRECT for same data_hash is skipped as duplicate', async () => {
+    const inputA = createTestInput('direct');
+    const workflowA = createScoreSubmissionWorkflow(inputA);
+
+    // Use distinct validator addresses to mimic two verifier instances
+    // sharing the same signer key (the real zombie-replica incident).
+    const inputB: ScoreSubmissionInput = {
+      ...inputA,
+      validator_address: '0xOtherValidator',
+    };
+    const workflowB = createScoreSubmissionWorkflow(inputB);
+
+    await persistence.create(workflowA);
+    await engine.startWorkflow(workflowA.id);
+
+    const savedA = await persistence.load(workflowA.id);
+    expect(savedA?.state).toBe('COMPLETED');
+    expect(savedA?.progress.score_confirmed).toBe(true);
+    expect(savedA?.progress.duplicate_skipped).toBeUndefined();
+
+    // Second workflow lands after A has reached COMPLETED (the common
+    // serialised case — the race-in-the-same-ms case is covered by the
+    // partial unique index migration).
+    await persistence.create(workflowB);
+    await engine.startWorkflow(workflowB.id);
+
+    const savedB = await persistence.load(workflowB.id);
+    expect(savedB?.state).toBe('COMPLETED');
+    expect(savedB?.progress.score_confirmed).toBe(true);
+    expect(savedB?.progress.duplicate_skipped).toBe(true);
+    expect(savedB?.progress.settlement).toBe('off-chain');
+  });
+
+  it('duplicate check only fires for workflows already COMPLETED', async () => {
+    // A CREATED-but-not-COMPLETED sibling must NOT block a new workflow
+    // from advancing. The partial unique index filter `state =
+    // 'COMPLETED'` + the application-level check
+    // `hasCompletedScoreForDataHash` both agree: only COMPLETED rows
+    // count as duplicates.
+    const inputA = createTestInput('direct');
+    const workflowA = createScoreSubmissionWorkflow(inputA);
+    // Place workflowA in CREATED/RUNNING state without completing it.
+    await persistence.create(workflowA);
+    // Note: we intentionally do NOT start workflowA, so no COMPLETED row
+    // exists for its data_hash yet.
+
+    const inputB: ScoreSubmissionInput = {
+      ...inputA,
+      validator_address: '0xSecondValidator',
+    };
+    const workflowB = createScoreSubmissionWorkflow(inputB);
+    await persistence.create(workflowB);
+    await engine.startWorkflow(workflowB.id);
+
+    const savedB = await persistence.load(workflowB.id);
+    expect(savedB?.state).toBe('COMPLETED');
+    expect(savedB?.progress.score_confirmed).toBe(true);
+    // workflowB was the first to reach COMPLETED, so it is canonical.
+    expect(savedB?.progress.duplicate_skipped).toBeUndefined();
+  });
 });
 
 // =============================================================================

--- a/packages/gateway/test/unit/work-status.test.ts
+++ b/packages/gateway/test/unit/work-status.test.ts
@@ -62,6 +62,7 @@ function createMockQuerySource(overrides: Partial<WorkflowQuerySource> = {}): Wo
     findFinalizedWorkForStudio: vi.fn().mockResolvedValue({ records: [], total: 0 }),
     findAllWorkForStudio: vi.fn().mockResolvedValue({ records: [], total: 0 }),
     findScoresForDataHash: vi.fn().mockResolvedValue([]),
+    findScoresForStudio: vi.fn().mockResolvedValue({ records: [], total: 0 }),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fixes duplicate ScoreSubmission workflows polluting the compare-page leaderboard averages, and adds a new read endpoint (`GET /v1/studio/:address/scores`) that exposes the cross-verifier canonical score view for downstream consumers.

## Background — the 2026-04-11 duplicate-scoring incident

On 2026-04-11 we saw Sumeet's report of multiple `SUBMIT_SCORE_DIRECT` workflows for the same `data_hash` in gateway logs. Digging into the logs (\`logs.1775881949426.json\`): **17 score submissions for 12 unique \`data_hash\`es** over a 22-hour window, all signed by the same \`validator_address\` (\`0xf81043d7866F5a90836a65E6ea37d38a38716F69\`). The duplicate rows had **identical first 3 score dimensions** (the deterministic SDK signals that our agent-server's \`signals_node\` computes) and **diverging last 2 dimensions** (the LLM-dependent compliance/efficiency scores from \`review_node\`). That pattern is unambiguous evidence of two verifier processes running the same pipeline against the same work item — not a workflow replay or a gateway double-fire.

The root cause on the agent-server side turned out to be a local development agent-server process that was pointed at the production gateway with the same verifier signer as the Railway-hosted production replica. Both instances were polling the same pending queue and racing on every new work item; the local process usually won (lower latency to the gateway than Railway's outbound path), which also explains why the Railway log for the production replica showed 283 consecutive verifier cycles with \`discovered=0, verified=0\` while the gateway was still receiving score submissions signed by the production verifier key. That local process had already been shut down before the investigation began, which also explains why a later \`ps aux\` sweep on the developer's machine came up empty.

Killing the local instance stopped the bleed, but left three structural issues in the gateway that any future multi-verifier deployment — a second local dev instance, a staging environment, Sumeet's own verifier, or a CI worker — would re-trigger:

1. **\`SubmitScoreDirectStep.execute\` had no cross-workflow idempotency.** It only checked \`progress.score_confirmed\` on its own workflow (re-entrancy after a crash) — nothing prevented two separate workflows for the same \`data_hash\` from both transitioning to COMPLETED concurrently.
2. **Duplicate rows directly pollute the compare-page canonical scores.** \`queryLeaderboardRows\` in \`sessions/routes.ts\` groups by \`agent_address\` and \`AVG\`s across every COMPLETED \`ScoreSubmission\` row, so duplicates don't just display twice — they shift the average and inflate \`scored_sessions\` counts.
3. **The compare dashboard had no way to see cross-verifier scores.** The dashboard reads the agent-server's \`/v1/verify/results\` endpoint, which only ever returns what *this specific agent-server instance's verifier loop* wrote locally. When a different verifier instance wins the race, the dashboard appears blank even though the score exists on the gateway. The agent-server needs a gateway endpoint to query canonical scores.

## What changed

### 1. Cross-workflow idempotency — application layer

\`packages/gateway/src/workflows/score-submission.ts\` — \`SubmitScoreDirectStep.execute\` now calls \`persistence.hasCompletedScoreForDataHash\` before persisting progress. If a completed ScoreSubmission already exists for this \`data_hash\`, the new workflow no-ops into a clean \`SUCCESS\` with \`progress.duplicate_skipped: true\`, so callers see a success status rather than a retry loop or error. The first winner is canonical; we never overwrite it.

The method was already implemented on both \`InMemoryWorkflowPersistence\` and \`PostgresWorkflowPersistence\` — it was declared in \`persistence.ts\` so \`SubmitScoreDirectStep\` can actually call it.

### 2. DB-level partial unique index — defence in depth

New migration V5 (\`packages/gateway/src/persistence/postgres/migrations/005_score_dedup.sql\` plus an inline \`MIGRATION_V5_SQL\` block in \`persistence.ts\` so \`runMigrations\` picks it up on startup):

\`\`\`sql
CREATE UNIQUE INDEX IF NOT EXISTS idx_score_submission_data_hash_completed
    ON workflows ((input->>'data_hash'))
    WHERE type = 'ScoreSubmission' AND state = 'COMPLETED';
\`\`\`

This closes the TOCTOU race between the application-level check and the \`UPDATE\` that marks the workflow COMPLETED. If two workflows for the same \`data_hash\` pass the application check in the same millisecond, whichever \`UPDATE\` fires second gets pg error \`23505\`. \`SubmitScoreDirectStep\` catches that via \`isDuplicateScoreViolation()\` and converts it into the same no-op success as the application-level check.

The filter \`WHERE state = 'COMPLETED'\` means \`CREATED\`/\`RUNNING\`/\`STALLED\`/\`FAILED\` rows for the same \`data_hash\` can still coexist freely — only the transition *into* COMPLETED is serialised, which is exactly where duplication matters.

### 3. New endpoint — \`GET /v1/studio/:address/scores\`

Returns canonical per-work score vectors for a studio, optionally filtered by \`worker_address\` or \`validator_address\`, sorted \`updated_at\` descending.

\`\`\`json
{
  \"version\": \"v1\",
  \"data\": {
    \"studio\": \"0xfa0795fd5d7f58ecaa7eae35ad9cb8aed9424dd0\",
    \"scores\": [
      {
        \"data_hash\": \"0x191e36dc...\",
        \"studio_address\": \"0xfa07...\",
        \"worker_address\": \"0xc4bd6d0d...\",
        \"validator_address\": \"0xf81043d7...\",
        \"scores_bp\": [7000, 0, 699, 3000, 2500],
        \"submitted_at\": \"2026-04-11T01:44:36.546Z\",
        \"workflow_id\": \"1ab88784-0b3c-42c2-8501-3e106fbab443\"
      }
    ],
    \"total\": 17,
    \"limit\": 100,
    \"offset\": 0
  }
}
\`\`\`

- Gated by \`requireEvidenceKey\` (same auth story as \`/v1/work/:hash/evidence\`).
- Response shape mirrors the existing \`PendingWorkItem\` envelope so clients already consuming \`/v1/studio/:addr/work\` get a symmetric API.
- \`worker_address\` resolves from \`progress.resolved_worker_address\` first (the runtime-resolved value from the direct-mode pipeline) then falls back to \`input.worker_address\`, matching what \`SubmitScoreDirectStep\` writes.
- New persistence method \`findScoresForStudio(studioAddress, filter, limit, offset)\` on both \`InMemoryWorkflowPersistence\` and \`PostgresWorkflowPersistence\`, with full \`WorkflowPersistence\` interface wiring and an equivalent mock in \`work-data-reader.ts\`'s \`WorkflowQuerySource\`.

This endpoint's primary consumer is the companion [agent-server PR](https://github.com/ChaosChain/chaoschain-agent-server/pull/16), which updates its \`/v1/verify/results\` endpoint to read this canonical view and merge its local ReAct rationale onto the gateway rows. The agent-server PR ships a defensive fallback to its pre-merge behaviour if this endpoint returns 404, so it's safe to deploy before this PR is merged.

## Files changed

| File | What |
|---|---|
| \`packages/gateway/src/workflows/persistence.ts\` | Declare \`hasCompletedScoreForDataHash\` and \`findScoresForStudio\` on the \`WorkflowPersistence\` interface + implement \`findScoresForStudio\` on \`InMemoryWorkflowPersistence\`. |
| \`packages/gateway/src/workflows/score-submission.ts\` | Idempotency check in \`SubmitScoreDirectStep.execute\` + \`isDuplicateScoreViolation\` helper for 23505 handling. |
| \`packages/gateway/src/persistence/postgres/persistence.ts\` | New \`MIGRATION_V5_SQL\` block + \`findScoresForStudio\` SQL implementation. |
| \`packages/gateway/src/persistence/postgres/migrations/005_score_dedup.sql\` | Standalone migration file for ops that runs migrations from SQL files. |
| \`packages/gateway/src/services/work-data-reader.ts\` | \`WorkflowQuerySource.findScoresForStudio\` interface + \`StudioScoresResult\` / \`StudioScoreRecord\` types + \`WorkDataReader.getStudioScores\`. |
| \`packages/gateway/src/routes/public-api.ts\` | Register \`GET /v1/studio/:address/scores\` route. |
| \`packages/gateway/test/unit/score-submission.test.ts\` | +2 cases for duplicate-skip behaviour. |
| \`packages/gateway/test/unit/public-api.test.ts\` | +6 cases for \`/v1/studio/:addr/scores\` + new \`addScoreWorkflow\` mock helper + \`findScoresForStudio\` stub. |
| \`packages/gateway/test/unit/work-status.test.ts\` | \`findScoresForStudio\` stub. |
| \`packages/gateway/test/integration/context-verifier-flow.test.ts\` | \`findScoresForStudio\` stub. |

## Test plan

- [x] \`pnpm tsc --noEmit\` — clean typecheck in \`packages/gateway\`
- [x] \`pnpm vitest run test/unit\` — **464 passed / 28 skipped / 0 failed** across 22 test files
- [x] New coverage:
  - [x] \`score-submission.test.ts > second SUBMIT_SCORE_DIRECT for same data_hash is skipped as duplicate\`
  - [x] \`score-submission.test.ts > duplicate check only fires for workflows already COMPLETED\`
  - [x] \`public-api.test.ts > GET /v1/studio/:address/scores\` (6 cases: happy path, worker filter, 400 invalid studio, 400 invalid worker, 401 unauthenticated, pagination)
- [ ] **After merge + Railway redeploy**: run a worldline compare round and verify the gateway log shows exactly one \`[SUBMIT_SCORE_DIRECT] off-chain score persisted\` line per \`data_hash\`. If a second verifier is ever brought up, check that the gateway log shows \`[SUBMIT_SCORE_DIRECT] duplicate skipped: data_hash=... already has a completed score ...\` and the \`workflows\` table has only one COMPLETED row for that \`data_hash\`.
- [x] **Backfill note**: the partial unique index will fail to create if the \`workflows\` table already contains duplicate COMPLETED ScoreSubmission rows for any \`data_hash\` (the 2026-04-10 incident left ~5 such pairs). Recommend running this cleanup before or during the deploy:
  \`\`\`sql
  -- Keep the earliest COMPLETED row per (data_hash), delete the rest.
  DELETE FROM workflows w
    USING workflows w2
    WHERE w.type = 'ScoreSubmission'
      AND w.state = 'COMPLETED'
      AND w2.type = 'ScoreSubmission'
      AND w2.state = 'COMPLETED'
      AND w.input->>'data_hash' = w2.input->>'data_hash'
      AND w.created_at > w2.created_at;
  \`\`\`
  Alternatively, if you'd rather the migration itself handle this, I can push a \`MIGRATION_V5_CLEANUP_SQL\` block that runs the DELETE inside the same \`DO $$\` transaction before creating the index.

## Related

- https://github.com/ChaosChain/chaoschain-agent-server/pull/16 — companion agent-server PR that consumes the new \`/v1/studio/:addr/scores\` endpoint in its \`/v1/verify/results\` merge and ships defensive fallback for rollout safety.
